### PR TITLE
[infra] Fix issue w/ missed node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
-node_modules
-build
+node_modules/
+build/
 .dockerignore
 Dockerfile
 Dockerfile.prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   frontend:
     build: ./womparator/frontend
     volumes:
-      - ./womparator/frontend:/usr/src/app
+      - ./womparator/frontend/public:/frontend/public
+      - ./womparator/frontend/src:/frontend/src
     depends_on:
       - backend
     ports:
@@ -12,6 +13,6 @@ services:
   backend:
     build: ./womparator/backend
     volumes:
-      - ./womparator/backend:/app
+      - ./womparator/backend:/backend
     ports:
       - "${WOMP_BACK_PORT}:8080"

--- a/womparator/backend/Dockerfile
+++ b/womparator/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-slim-bookworm
 
-WORKDIR /app
+WORKDIR /backend
 
 COPY ./requirements.txt .
 

--- a/womparator/frontend/Dockerfile
+++ b/womparator/frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:18-slim
 
-WORKDIR /usr/src/app
+WORKDIR /frontend
 
 COPY ./package.json .
 COPY ./yarn.lock .
@@ -10,7 +10,5 @@ RUN yarn install
 
 # copy app files
 COPY . .
-
-EXPOSE 3000
 
 CMD [ "yarn", "run", "start-watch" ]


### PR DESCRIPTION
- node_modules directory was shared between host & container via volume. As a result, container's node_modules/ could be erased if there was no such directory on host
- Issue is fixed by preventing node_modules from mounting (making it isolated)